### PR TITLE
inference에서 KeyError: 'token_type_ids' 발생

### DIFF
--- a/code/inference.py
+++ b/code/inference.py
@@ -103,7 +103,8 @@ def main(args):
     )
     # "model_data_epoch_bsz.csv" 형식으로 저장
     MODEL_NAME = cfg["params"]["MODEL_NAME"]
-    MODEL_NAME = MODEL_NAME.split("/")[0] + "-" + MODEL_NAME.split("/")[-1]
+    if "/" in MODEL_NAME:
+        MODEL_NAME = MODEL_NAME.split("/")[0] + "-" + MODEL_NAME.split("/")[-1]
     DATA_NAME = cfg["path"]["train_path"]
     DATA_NAME = DATA_NAME.split("/")[-1]
     DATA_NAME = DATA_NAME.split(".")[0]


### PR DESCRIPTION
## Overview
- 'xlm-roberta-large'와 같은 이름에서 모델이름도 잘 작동하도록 수정

## Change Log
- 

## Issue Tags
- closed | Fixed: #21 
- See also: #21 