### PR TITLE
[FEAT/24] validation 진행 및 output 파일 이름에 metrics 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 [Ss]cripts
 [Dd]ata
 [Oo]utput
+[Ww]andb
 
 __pycache__
 .empty

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Baseline 코드 리팩토링
+# [FEAT] validation 데이터로 평가 + 결과 확인 -> output 파일 이름에 metrics 추가
 
 ## 변경된 사항
 
@@ -7,7 +7,7 @@ train_path, valid_path의 데이터를 읽어들여서 학습 후 평가를 진�
 
 2. inference.py
 metrics.yaml파일의 F1 score, AUPRC 읽어온 후, output 파일의 이름에 순서대로 추가합니다.
-  ex) klue-bert-base_train_new_10_66.7669_66.6981.csv
+  ex) 생성 파일 : klue-bert-base_train_new_10_32_66.7669_66.6981.csv
 
 
 ## 초기 설정(중요!)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## 변경된 사항
 
-1. Makefile 추가로 사용성 증진 예상
-2. 커밋을 하면 자동으로 [코드 포맷팅](https://www.notion.so/7664352c799249dfa17e7558e6aa2eb7?pvs=21)
-3. 폴더 분리
-4. gitignore 수정으로 기본 세팅의 config 파일을 포함
-5. train.py의 주석을 보기 좋게 수정
-6. 쉘코드 추가로 여러개 연속으로 학습 가능
-7. 저장된 output 파일 이름이 config 파일에 맞게 수정
+1. train.py
+train_path, valid_path의 데이터를 읽어들여서 학습 후 평가를 진행합니다. 평가 후 F1 Score, AUPRC를 model_path에 metrics.yaml파일로 기록합니다.
+
+2. inference.py
+metrics.yaml파일의 F1 score, AUPRC 읽어온 후, output 파일의 이름에 순서대로 추가합니다.
+  ex) klue-bert-base_train_new_10_66.7669_66.6981.csv
+
 
 ## 초기 설정(중요!)
 
@@ -23,7 +23,7 @@
    4. 그리고 `config.yaml` 파일에서 train_path를 `train_new.csv` 으로 변경!
 4. `config2.yaml`처럼 config 디렉토리에 `config`뒤에 이름을 자유롭게 .yaml 파일을 추가해주세요(개수 제한 없음)
 
-## 사용방법
+## 사용방법(동일)
 
 ### 1. train + inference
 

--- a/code/inference.py
+++ b/code/inference.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import pickle as pickle
 
 import numpy as np
@@ -91,6 +92,14 @@ def main(args):
     pred_answer, output_prob = inference(model, Re_test_dataset, device)  # model에서 class 추론
     pred_answer = num_to_label(pred_answer)  # 숫자로 된 class를 원래 문자열 라벨로 변환.
 
+    # YAML 파일에서 F1 Score, AUPRC 읽어오기
+    with open(args.model_dir + "/metrics.yaml", "r") as yaml_file:
+        config_data = yaml.load(yaml_file, Loader=yaml.FullLoader)
+        
+    # 값을 읽어오기 - 없으면 -1 반환, 소수점 4자리까지 반올림
+    MICRO_F1 = str(round(config_data.get("micro_f1", -1), 4))  
+    AUPRC = str(round(config_data.get("auprc", -1), 4))          
+
     ## make csv file with predicted answer
     #########################################################
     # 아래 directory와 columns의 형태는 지켜주시기 바랍니다.
@@ -110,7 +119,7 @@ def main(args):
     DATA_NAME = DATA_NAME.split(".")[0]
     NUM_EPOCHS = str(cfg["params"]["num_train_epochs"])
     BATCH_SIZE = str(cfg["params"]["per_device_train_batch_size"])
-    FILE_NAME = [MODEL_NAME, DATA_NAME, NUM_EPOCHS, BATCH_SIZE]
+    FILE_NAME = [MODEL_NAME, DATA_NAME, NUM_EPOCHS, BATCH_SIZE, MICRO_F1, AUPRC]
     FILE_NAME = "_".join(FILE_NAME) + ".csv"
     print(cfg["path"]["submission_path"] + FILE_NAME)
     output.to_csv(cfg["path"]["submission_path"] + FILE_NAME, index=False)

--- a/code/train.py
+++ b/code/train.py
@@ -1,16 +1,19 @@
 import argparse
 import os
 import pickle as pickle
+import pytz
+
 
 import numpy as np
 import pandas as pd
 import sklearn
 import torch
+import wandb
 import yaml
 from load_data import *
 from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
 from transformers import AutoConfig, AutoModelForSequenceClassification, AutoTokenizer, BertTokenizer, RobertaConfig, RobertaForSequenceClassification, RobertaTokenizer, Trainer, TrainingArguments
-
+from datetime import datetime
 
 def klue_re_micro_f1(preds, labels):
     """KLUE-RE micro f1 (except no_relation)"""
@@ -125,6 +128,8 @@ def train():
     print(model.config)
     model.parameters
     model.to(device)
+    os.environ["WANDB_PROJECT"] = "<Lv2-KLUE>"  # wandb 프로젝트명 설정
+
 
     # 사용한 option 외에도 다양한 option들이 있습니다.
     # https://huggingface.co/transformers/main_classes/trainer.html#trainingarguments 참고해주세요.
@@ -146,6 +151,8 @@ def train():
         #                                                                           `epoch`: Evaluate every end of epoch.
         eval_steps=cfg["params"]["eval_steps"],  #                                   evaluation step.
         load_best_model_at_end=cfg["params"]["load_best_model_at_end"],
+        report_to="wandb",  # enable logging to W&B
+        run_name=f"{MODEL_NAME}_{cfg['params']['num_train_epochs']:02d}_{cfg['params']['per_device_train_batch_size']}_{cfg['params']['learning_rate']}_{datetime.now(pytz.timezone('Asia/Seoul')):%y%m%d%H%M}"  # name of the W&B run (optional)
     )
 
     trainer = Trainer(
@@ -159,13 +166,16 @@ def train():
     # train model
     trainer.train()
     model.save_pretrained(cfg["path"]["MODEL_PATH"])
-
+    
+    
 
     # evaluate 메서드를 통해 평가 수행
     evaluation_results = trainer.evaluate()
 
     # evaluation_results에는 compute_metrics 함수에서 반환한 메트릭들이 포함됨
     print("평가결과 : ", evaluation_results)
+    
+    wandb.finish()
     
 # yaml 파일 불러오기
 def load_config(config_file):
@@ -176,7 +186,7 @@ def load_config(config_file):
 
 def main():
     train()
-
+    
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/code/train.py
+++ b/code/train.py
@@ -167,13 +167,33 @@ def train():
     trainer.train()
     model.save_pretrained(cfg["path"]["MODEL_PATH"])
     
-    
-
     # evaluate 메서드를 통해 평가 수행
     evaluation_results = trainer.evaluate()
 
     # evaluation_results에는 compute_metrics 함수에서 반환한 메트릭들이 포함됨
     print("평가결과 : ", evaluation_results)
+    
+    # micro f1 score, auprc 추출
+    micro_f1 = evaluation_results["eval_micro f1 score"]
+    auprc = evaluation_results["eval_auprc"]
+    print("micro_f1, auprc : ", micro_f1, auprc)
+    
+    # YAML 파일로 저장
+    config_data = {
+        "micro_f1": micro_f1,
+        "auprc": auprc
+    }
+    with open(cfg["path"]["MODEL_PATH"] + "/metrics.yaml", "w") as yaml_file:
+        yaml.dump(config_data, yaml_file)
+    
+    
+    
+    #환경변수로 저장 -> inference.py 파일에서 사용 예정
+    #os.environ["MICRO_F1"] = str(micro_f1)
+    #os.environ["AUPRC"] = str(auprc)
+    
+    
+    
     
     wandb.finish()
     


### PR DESCRIPTION
## Overview
- valid.csv로 평가한 F1 Score, AUPRC를 output 파일 이름에 추가하기

description:
make로 이용(동일)


## Change Log
train.py: 
- train_path, valid_path의 데이터를 읽어들여서 학습 후 평가를 진행합니다. 평가 후 F1 Score, AUPRC를 model_path에 metrics.yaml파일로 기록합니다.

inference.py: 
- metrics.yaml파일의 F1 score, AUPRC를 읽어온 후, output 파일의 이름에 순서대로 추가합니다.
    ex) klue-bert-base_train_new_10_66.7669_66.6981.csv

wandb:
- wandb를 연동해서 로그인한 계정의 &lt;Lv2-KLUE&gt; 라는 프로젝트에서 run이 실행됩니다.


## Issue Tags
close #24 